### PR TITLE
refactor: remove jquery

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,19 +6,19 @@
 
     <link rel="icon" type="image/ico" href="/favicon.ico" />
 
-    <title>Whiteboard</title>
+    <title>Canvas</title>
   </head>
 
   <body>
     <main class="min-h-screen bg-gray-100 flex flex-col">
       <header class="md:flex md:items-center md:justify-between p-4 md:pb-4">
         <div>
-          <h1 class="font-sans font-extralight uppercase leading-none text-xl text-grey-darkest">Whiteboard</h1>
+          <h1 class="font-sans font-extralight uppercase leading-none text-xl text-grey-darkest">Canvas</h1>
         </div>
 
         <div class="flex space-x-4 text-gray-600">
-          <label for="pen-shape">Tool</label>
-          <select class="" id="pen-shape">
+          <label for="penShape">Tool</label>
+          <select id="penShape" class="cursor-pointer">
             <option value="pencil">Pencil</option>
             <option value="line">Line</option>
             <option value="rectangle">Rectangle</option>
@@ -28,14 +28,16 @@
           </select>
 
           <label for="penSize">Size</label>
-          <select id="penSize">
+          <select id="penSize" class="cursor-pointer">
             <option value="4">Normal</option>
             <option value="2">Thin</option>
             <option value="8">Thick</option>
           </select>
 
-          <label for="penColor">Color</label>
-          <input id="penColor" />
+          <div class="flex">
+            <div class="pr-4">Color</div>
+            <div id="penColor" class="w-10 border border-black cursor-pointer"></div>
+          </div>
         </div>
 
         <div class="text-white">
@@ -47,7 +49,7 @@
         </div>
       </header>
 
-      <div id="canvas-container" class="">
+      <div id="canvas-container">
         <canvas id="my-canvas" class="bg-white" height="700" width=""></canvas>
         <div class="text-spawner"></div>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,6 +112,11 @@
         "fastq": "^1.6.0"
       }
     },
+    "@sphinxxxx/color-conversion": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@sphinxxxx/color-conversion/-/color-conversion-2.2.2.tgz",
+      "integrity": "sha512-XExJS3cLqgrmNBIP3bBw6+1oQ1ksGjFh0+oClDKFYpCCqx/hlqwWO5KO/S63fzUo67SxI9dMrF0y5T/Ey7h8Zw=="
+    },
     "@tailwindcss/jit": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/jit/-/jit-0.1.4.tgz",
@@ -128,15 +133,6 @@
         "quick-lru": "^5.1.1"
       }
     },
-    "@types/jquery": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.5.tgz",
-      "integrity": "sha512-6RXU9Xzpc6vxNrS6FPPapN1SxSHgQ336WC6Jj/N8q30OiaBZ00l1GBgeP7usjVZPivSkGUfL1z/WW6TX989M+w==",
-      "dev": true,
-      "requires": {
-        "@types/sizzle": "*"
-      }
-    },
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -147,12 +143,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true
-    },
-    "@types/sizzle": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
-      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -1701,11 +1691,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2542,11 +2527,6 @@
       "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
       "dev": true
     },
-    "spectrum-colorpicker": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/spectrum-colorpicker/-/spectrum-colorpicker-1.8.1.tgz",
-      "integrity": "sha512-x1picQ5giVso71ESII7jZ3+ZFdit8WthNkzwJqLNdPDPzrltKUQGpTohWyPfSAID+bK1zGdO6bDbSh1S6GoLYA=="
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -2820,6 +2800,14 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "vanilla-picker": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/vanilla-picker/-/vanilla-picker-2.11.2.tgz",
+      "integrity": "sha512-2cP7LlUnxHxwOf06ReUVtd2RFJMnJGaxN2s0p8wzBH3In5b00Le7fFZ9VrIoBE0svZkSq/BC/Pwq/k/9n+AA2g==",
+      "requires": {
+        "@sphinxxxx/color-conversion": "^2.2.2"
       }
     },
     "vite": {

--- a/package.json
+++ b/package.json
@@ -12,12 +12,10 @@
   },
   "license": "ISC",
   "dependencies": {
-    "jquery": "3.6.0",
-    "spectrum-colorpicker": "1.8.1"
+    "vanilla-picker": "2.11.2"
   },
   "devDependencies": {
     "@tailwindcss/jit": "0.1.4",
-    "@types/jquery": "3.5.5",
     "@typescript-eslint/eslint-plugin": "4.18.0",
     "@typescript-eslint/parser": "4.18.0",
     "autoprefixer": "10.2.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,4 @@
-import $ from "jquery";
-
-import "spectrum-colorpicker/spectrum.css";
-import "spectrum-colorpicker";
-import "./style.css";
-
+import Picker from "vanilla-picker";
 import ResizeCanvas from "./utils/resizer";
 import Canvas from "./utils/canvas";
 import Pencil from "./models/pencil";
@@ -11,72 +6,80 @@ import Line from "./models/line";
 import Rectangle from "./models/rectangle";
 import Circle from "./models/circle";
 import Text from "./models/text";
+import "./style.css";
+import { getConfig } from "./utils/config";
 
-$(() => {
+(() => {
+  const penShapeElement = document.querySelector("#penShape") as HTMLSelectElement;
+  const penSizeElement = document.querySelector("#penSize") as HTMLSelectElement;
+  const penColorElement = document.querySelector("#penColor") as HTMLSelectElement;
+  const canvasElement = document.querySelector("#my-canvas") as HTMLCanvasElement;
+
+  const config = getConfig();
+
+  penShapeElement.value = config.penShape;
+  penSizeElement.value = String(config.penSize);
+
   // Resize the whiteboard to match width and height of window
-  ResizeCanvas();
-  $(window).on("resize", ResizeCanvas);
+  ResizeCanvas(canvasElement);
+  window.addEventListener("resize", () => ResizeCanvas(canvasElement));
 
-  const canvasElement = document.getElementById("my-canvas") as HTMLCanvasElement;
   const canvas: Canvas = new Canvas(canvasElement);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const colorPicker = $("#penColor") as any;
-  colorPicker.spectrum({
-    preferredFormat: "hex",
+
+  penColorElement.style.background = config.penColor;
+  new Picker({
+    parent: penColorElement,
+    color: config.penColor,
+    onDone: function (color) {
+      penColorElement.style.background = color.hex;
+      canvas.penColor = color.hex;
+    },
   });
 
-  $("#pen-shape").on("change", (ev: JQuery.EventBase): void => {
-    canvas.penShape = ev.target["value"];
+  const readValue = <T>(ev: Event, fallback: T): T => (ev.target ? ev.target["value"] : fallback);
+
+  penShapeElement.addEventListener("change", (ev) => {
+    canvas.penShape = readValue(ev, canvas.penShape);
   });
 
-  $("#penSize").on("change", (ev: JQuery.EventBase): void => {
-    canvas.penSize = ev.target["value"];
+  penSizeElement.addEventListener("change", (ev) => {
+    canvas.penSize = readValue(ev, canvas.penSize);
   });
 
-  $("#penColor").on("change", (ev: JQuery.EventBase): void => {
-    canvas.penColor = ev.target["value"];
+  document.querySelector("#clear-canvas")?.addEventListener("click", () => canvas.clearCanvas());
+  document.querySelector("#undo")?.addEventListener("click", () => canvas.redoShape());
+  document.querySelector("#redo")?.addEventListener("click", () => canvas.undoShape());
+
+  canvasElement.addEventListener("mousedown", (ev): void => {
+    if (ev.target) {
+      const x0 = ev.pageX - ev.target["offsetLeft"];
+      const y0 = ev.pageY - ev.target["offsetTop"];
+      canvas.addShape(x0, y0, ev);
+    }
   });
 
-  $("#clear-canvas").on("click", (): void => canvas.clearCanvas());
-  $("#undo").on("click", (): void => canvas.redoShape());
-  $("#redo").on("click", (): void => canvas.undoShape());
-
-  $("#my-canvas").mousedown((ev: JQuery.MouseDownEvent): void => {
-    const x0 = ev.pageX - ev.target["offsetLeft"];
-    const y0 = ev.pageY - ev.target["offsetTop"];
-    canvas.addShape(x0, y0, ev);
-  });
-
-  $("#my-canvas").mousemove((ev: JQuery.MouseMoveEvent): void => {
-    if (canvas.isDrawing) {
+  canvasElement.addEventListener("mousemove", (ev): void => {
+    if (canvas.isDrawing && ev.target) {
       const x0 = ev.pageX - ev.target["offsetLeft"];
       const y0 = ev.pageY - ev.target["offsetTop"];
       const width = x0 - canvas.currentShape.position.x;
       const height = y0 - canvas.currentShape.position.y;
-      let currShape;
-
-      // TODO: Find a way to remove the casting step
 
       switch (canvas.penShape) {
         case "pencil":
-          currShape = canvas.currentShape as Pencil;
-          currShape.addPoint(x0, y0);
+          (canvas.currentShape as Pencil).addPoint(x0, y0);
           break;
         case "line":
-          currShape = canvas.currentShape as Line;
-          currShape.setEndPoint(x0, y0);
+          (canvas.currentShape as Line).setEndPoint(x0, y0);
           break;
         case "rectangle":
-          currShape = canvas.currentShape as Rectangle;
-          currShape.setSize(width, height);
+          (canvas.currentShape as Rectangle).setSize(width, height);
           break;
         case "circle":
-          currShape = canvas.currentShape as Circle;
-          currShape.setSize(x0, y0);
+          (canvas.currentShape as Circle).setSize(x0, y0);
           break;
         case "eraser":
-          currShape = canvas.currentShape as Pencil;
-          currShape.addPoint(x0, y0);
+          (canvas.currentShape as Pencil).addPoint(x0, y0);
           break;
       }
 
@@ -86,7 +89,7 @@ $(() => {
     }
   });
 
-  $("#my-canvas").mouseup((): void => {
+  canvasElement.addEventListener("mouseup", (): void => {
     if (canvas.penShape !== "text") {
       canvas.shapes.push(canvas.currentShape);
       canvas.redraw();
@@ -95,11 +98,11 @@ $(() => {
     canvas.isDrawing = false;
   });
 
-  $(".text-spawner").keydown((ev: JQuery.KeyDownEvent): void => {
+  (document.querySelector(".text-spawner") as HTMLTextAreaElement).addEventListener("keydown", (ev): void => {
     if (canvas.isDrawing) {
       if (ev.which === 13) {
         const currShape = canvas.currentShape as Text;
-        currShape.setText = canvas.currentInputBox.val() as string;
+        currShape.setText = canvas.currentInputBox.value;
 
         canvas.shapes.push(canvas.currentShape);
         canvas.currentShape.draw(canvas.ctx);
@@ -112,4 +115,4 @@ $(() => {
       }
     }
   });
-});
+})();

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -1,4 +1,4 @@
-import $ from "jquery";
+import { getConfig, KEYS, setKey } from "./config";
 import Pencil from "../models/pencil";
 import Line from "../models/line";
 import Rectangle from "../models/rectangle";
@@ -9,7 +9,7 @@ import Point from "../models/point";
 
 export default class Canvas {
   public ctx: CanvasRenderingContext2D;
-  public currentInputBox!: JQuery;
+  public currentInputBox!: HTMLInputElement;
   public currentShape!: Shape;
   public shapes: Shape[] = [];
   public undoObjects: Shape[] = [];
@@ -20,6 +20,13 @@ export default class Canvas {
 
   constructor(public canvas: HTMLCanvasElement) {
     this.ctx = canvas.getContext("2d") || new CanvasRenderingContext2D();
+
+    const config = getConfig();
+    if (config) {
+      this.penColor = config.penColor;
+      this.penShape = config.penShape;
+      this.penSize = config.penSize;
+    }
   }
 
   public get penShape(): string {
@@ -28,6 +35,7 @@ export default class Canvas {
 
   public set penShape(shape: string) {
     this._penShape = shape;
+    setKey(KEYS.penShape, shape);
   }
 
   public get penColor(): string {
@@ -36,6 +44,7 @@ export default class Canvas {
 
   public set penColor(color: string) {
     this._penColor = color;
+    setKey(KEYS.penColor, color);
   }
 
   public get penSize(): number {
@@ -44,9 +53,10 @@ export default class Canvas {
 
   public set penSize(size: number) {
     this._penSize = size;
+    setKey(KEYS.penSize, String(size));
   }
 
-  public addShape(x: number, y: number, ev: JQuery.MouseEventBase): void {
+  public addShape(x: number, y: number, ev: MouseEvent): void {
     this.isDrawing = true;
     const rect = this.canvas.getBoundingClientRect();
 
@@ -152,12 +162,12 @@ export default class Canvas {
       this.currentInputBox.remove();
     }
 
-    this.currentInputBox = $("<input />");
-    this.currentInputBox.css("position", "fixed");
-    this.currentInputBox.css("top", y);
-    this.currentInputBox.css("left", x);
+    this.currentInputBox = document.createElement("input");
+    this.currentInputBox.style.position = "fixed";
+    this.currentInputBox.style.top = `${y}px`;
+    this.currentInputBox.style.left = `${x}px`;
 
-    $(".text-spawner").append(this.currentInputBox);
+    document.querySelector(".text-spawner")?.append(this.currentInputBox);
     this.currentInputBox.focus();
   }
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,31 @@
+const DEFAULTS = Object.freeze({
+  penColor: "black",
+  penShape: "pencil",
+  penSize: 4,
+});
+
+export const KEYS = Object.freeze({
+  penColor: "canvas-pen-color",
+  penShape: "canvas-pen-shape",
+  penSize: "canvas-pen-size",
+});
+
+export type Config = {
+  penColor: string;
+  penShape: string;
+  penSize: number;
+};
+
+export function setKey(key: string, value: string): void {
+  localStorage.setItem(key, value);
+}
+
+export function getConfig(): Config {
+  const config: Config = {
+    penColor: localStorage.getItem(KEYS.penColor) ?? DEFAULTS.penColor,
+    penShape: localStorage.getItem(KEYS.penShape) ?? DEFAULTS.penShape,
+    penSize: Number(localStorage.getItem(KEYS.penSize) ?? DEFAULTS.penSize),
+  };
+
+  return config;
+}

--- a/src/utils/resizer.ts
+++ b/src/utils/resizer.ts
@@ -1,11 +1,7 @@
-import $ from "jquery";
+export default function ResizeCanvas(canvasElement: HTMLCanvasElement): void {
+  const container = document.querySelector("#canvas-container") as HTMLDivElement;
+  const canvas = canvasElement;
 
-export default function ResizeCanvas(): void {
-  const container = $("#canvas-container");
-  const canvas = $("#my-canvas");
-  const canvasWidth = container.width() as number;
-  const canvasHeight = container.height() as number;
-
-  canvas.attr("width", canvasWidth);
-  canvas.attr("height", canvasHeight);
+  canvas.setAttribute("width", String(container.clientWidth));
+  canvas.setAttribute("height", String(container.clientHeight));
 }


### PR DESCRIPTION
This PR refactors jQuery out of the application. With this change, I switched out the spectrum color picker for `vanilla-picker`. The bundle decreased by over 6x and build times by over 3x!

Here are some bundle stats from the change:

before: 

```
vite v2.1.2 building for production...
✓ 18 modules transformed.
dist/assets/favicon.9ccd84b4.ico   15.04kb
dist/index.html                    2.30kb
dist/assets/index.5c93a626.js      6.22kb / brotli: 1.74kb
dist/assets/index.ed5e98c6.css     13.42kb / brotli: 3.76kb
dist/assets/vendor.82562c7a.js     115.37kb / brotli: 35.98kb
npm run build  6.31s user 0.46s system 147% cpu 4.588 total
```

after:

```
vite v2.1.2 building for production...
✓ 15 modules transformed.
dist/assets/favicon.9ccd84b4.ico   15.04kb
dist/index.html                    2.41kb
dist/assets/index.944a1da8.css     5.27kb / brotli: 1.58kb
dist/assets/index.0418d391.js      7.34kb / brotli: 2.01kb
dist/assets/vendor.236a05f6.js     18.98kb / brotli: 5.88kb
npm run build  2.19s user 0.34s system 135% cpu 1.872 total
```